### PR TITLE
initial trial feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ cargo run .local.config.yml
 ### Dependencies
 
 - cmake
+- libssl-dev
 
 ## Zeroconf Probing
 

--- a/example.yml
+++ b/example.yml
@@ -2,7 +2,7 @@ lnd:
   macaroon_location: "~/.lnd/data/chain/bitcoin/mainnet/admin.macaroon"
   cert_location: "~/.lnd/tls.cert"
   host: "127.0.0.1"
-  port: 9735
-channel_acceptance: 
+  port: 10009
+channel_acceptance:
   - pubkey: ""
     confs: 0


### PR DESCRIPTION
I think the port number here is wrong, it didnt work until I switched it to the LND GRPC port 10009. It was suspicious though because it didnt error out either when using the wrong port, it just didnt work.

```
$ cargo run .local.config.yml
    Finished dev [unoptimized + debuginfo] target(s) in 0.06s
     Running `target/debug/zero-conf-lnd .local.config.yml`
2023-02-24T17:10:02.814718Z  INFO zero_conf_lnd::lnd: starting connection to lnd
2023-02-24T17:10:02.856338Z  INFO zero_conf_lnd::lnd: starting channel acceptor
```

I also needed an extra  dependency for the Rust build.